### PR TITLE
Fixed to maintain markers zIndex

### DIFF
--- a/lib/oms.coffee
+++ b/lib/oms.coffee
@@ -159,7 +159,7 @@ class @['OverlappingMarkerSpiderfier']
         marker.addEventListener('mouseover', mhl.highlight)
         marker.addEventListener('mouseout',  mhl.unhighlight)
       marker.setLatLng(footLl)
-      marker.setZIndexOffset(1000000)
+      marker.setZIndexOffset(marker.options.zIndexOffset + 1000000)
       marker
     delete @spiderfying
     @spiderfied = yes
@@ -174,7 +174,7 @@ class @['OverlappingMarkerSpiderfier']
       if marker['_omsData']?
         @map.removeLayer(marker['_omsData'].leg)
         marker.setLatLng(marker['_omsData'].usualPosition) unless marker is markerNotToMove
-        marker.setZIndexOffset(0)
+        marker.setZIndexOffset(marker.options.zIndexOffset - 0)
         mhl = marker['_omsData'].highlightListeners
         if mhl?
           marker.removeEventListener('mouseover', mhl.highlight)


### PR DESCRIPTION
Fixed a minor bug where the markers original zIndex was being changed when a marker was spiderfied/unspiderfied. 
Now instead of setting the zIndexOffset to 1000000, it is taking the existing zIndexOffset and adding/subtracting 1000000 to it when it spiderfies.