### PR TITLE
fixes #33

### DIFF
--- a/lib/oms.coffee
+++ b/lib/oms.coffee
@@ -171,6 +171,7 @@ class @['OverlappingMarkerSpiderfier']
     unspiderfiedMarkers = []
     nonNearbyMarkers = []
     for marker in @markers
+      continue unless @map.hasLayer(marker)
       if marker['_omsData']?
         @map.removeLayer(marker['_omsData'].leg)
         marker.setLatLng(marker['_omsData'].usualPosition) unless marker is markerNotToMove


### PR DESCRIPTION
I am not a coffee script guy, but this seems to fix the issue with different lengths of arrays for nonNearbyMarkers between spiderify and unspiderify.